### PR TITLE
Prevent PRs merged during deploy showing up

### DIFF
--- a/lib/capistrano/fiesta/editor.rb
+++ b/lib/capistrano/fiesta/editor.rb
@@ -7,7 +7,7 @@ module Capistrano
         @content = content
       end
 
-      def edit
+      def compose
         create_temp_file
         open
         read

--- a/lib/capistrano/fiesta/logger.rb
+++ b/lib/capistrano/fiesta/logger.rb
@@ -5,6 +5,7 @@ module Capistrano
 
       def self.warn(message)
         @logs << "[FIESTA] #{message}"
+        nil
       end
 
       def self.logs

--- a/test/report_test.rb
+++ b/test/report_test.rb
@@ -25,52 +25,52 @@ module Capistrano::Fiesta
       Report.chat_client = SlackDummy
     end
 
-    def test_create
+    def test_announce
       query = "base:master repo:balvig/capistrano-fiesta merged:>2015-10-09T14:50:23Z"
       response = { items: [{ title: "New login [Delivers #123]", body: "" }] }
       github = stub_request(:get, "https://api.github.com:443/search/issues").with(query: { q: query }).to_return_json(response)
 
-      announcement = <<-ANNOUNCEMENT
+      expected = <<-ANNOUNCEMENT
 • New login
       ANNOUNCEMENT
-      report = Report.create(repo, last_release: '20151009145023')
-      assert_equal announcement, report.announcement
+      announcement = Report.new(repo, last_release: '20151009145023').announce
+      assert_equal expected, announcement
       assert_requested github
     end
 
-    def test_create_with_comment
+    def test_announce_with_comment
       draft = <<-DRAFT
 # Only include new features
 
 • New login
       DRAFT
 
-      announcement = <<-ANNOUNCEMENT
+      expected = <<-ANNOUNCEMENT
 • New login
       ANNOUNCEMENT
 
-      report = Report.create(repo, comment: "Only include new features")
+      report = Report.new(repo, comment: "Only include new features")
+      announcement = report.announce
       assert_equal draft, report.send(:draft).render # find a way to set expectation on what Editor receives
-      assert_equal announcement, report.announcement
+      assert_equal expected, announcement
     end
 
     def test_creating_release_on_github
       release_endpoint = stub_request(:post, "https://api.github.com/repos/balvig/capistrano-fiesta/releases").with(body: { name: "20151009145023", body: "- [New login](www.github.com)", tag_name: "release-20151009145023" })
-      Report.create(repo).create_release('20151009145023')
+      Report.new(repo).create_release('20151009145023')
       assert_requested release_endpoint
     end
 
     def test_creating_release_with_no_stories
       stub_request(:get, /github.com/).to_return_json(items: [])
       release_endpoint = stub_request(:post, "https://api.github.com/repos/balvig/capistrano-fiesta/releases")
-      Report.create(repo).create_release('20151009145023')
+      Report.new(repo).create_release('20151009145023')
       assert_not_requested release_endpoint
       assert_equal "[FIESTA] No new stories, skipping GitHub release", Logger.logs.last
     end
 
-    def test_announce
-      report = Report.create(repo)
-      report.announce(team: 'bobcats', token: '1234', channel: 'releases')
+    def test_announce_with_options
+      Report.new(repo).announce(team: 'bobcats', token: '1234', channel: 'releases')
 
       post = {
         team: 'bobcats',
@@ -88,14 +88,13 @@ module Capistrano::Fiesta
 
     def test_announce_without_chat_client
       Report.chat_client = nil
-      report = Report.create(repo)
-      report.announce
-      assert_equal "[FIESTA] Install Slackistrano to announce releases on Slack", Logger.logs.last
+      Report.new(repo).announce
+      assert Logger.logs.last.include?("[FIESTA] Install Slackistrano to announce releases on Slack")
     end
 
     def test_announce_with_no_stories
       stub_request(:get, /github.com/).to_return_json(items: [])
-      Report.create(repo).announce
+      Report.new(repo).announce
       assert_equal "[FIESTA] Announcement blank, nothing posted to Slack", Logger.logs.last
     end
 


### PR DESCRIPTION
If something got merged during deploy, they would show up in the report even though not being deployed. This change fetches GitHub pull requests _before_ starting the deploy.