### PR TITLE
Set description for all tasks

### DIFF
--- a/lib/capistrano/tasks/fiesta.rake
+++ b/lib/capistrano/tasks/fiesta.rake
@@ -1,10 +1,11 @@
 namespace :fiesta do
-  desc 'Run a fiesta report'
+  desc 'Run a fiesta report and announce it'
   task :run do
     invoke 'fiesta:generate'
     invoke 'fiesta:announce'
   end
 
+  desc 'Generate a fiesta report'
   task :generate do
     run_locally do
       set :fiesta_report, Capistrano::Fiesta::Report.new(repo_url, last_release: last_release, comment: fetch(:fiesta_comment))
@@ -12,6 +13,7 @@ namespace :fiesta do
     end
   end
 
+  desc 'Announce a fiesta report'
   task :announce do
     run_locally do
       report.announce(slack_params)


### PR DESCRIPTION
Don't know if this PR is valid, but, I'm using capistrano 3.2.0 and if the task don't have `desc` when I run `fiesta:run` it tells me that `announce`  or `generate` tasks don't exist.

Thanks so much.
🍻 