### PR TITLE
allow adding release notes to PR body

### DIFF
--- a/lib/capistrano/fiesta/story.rb
+++ b/lib/capistrano/fiesta/story.rb
@@ -5,8 +5,8 @@ module Capistrano
         @pr = pr
       end
 
-      def title
-        @pr.title.sub(/\[Delivers #\S+\]\z/, '').strip
+      def release_note
+        (release_note_in_body || title).strip
       end
 
       def images
@@ -20,6 +20,16 @@ module Capistrano
       def to_markdown
         "- [#{title}](#{url})"
       end
+
+      private
+
+        def title
+          @pr.title.to_s.sub(/\[Delivers #\S+\]\z/, '')
+        end
+
+        def release_note_in_body
+          @pr.body.to_s[/_Release\snote\:(.+)_/m, 1]
+        end
     end
   end
 end

--- a/lib/capistrano/templates/draft.erb
+++ b/lib/capistrano/templates/draft.erb
@@ -2,8 +2,8 @@
 # <%= comment %>
 
 <% end -%>
-<% stories.sort_by(&:title).each do |story| -%>
-• <%= story.title %>
+<% stories.each do |story| -%>
+• <%= story.release_note %>
 <% story.images.each do |image| -%>
   <<%= image %>|Screenshot>
 <% end -%>

--- a/test/story_test.rb
+++ b/test/story_test.rb
@@ -2,14 +2,19 @@ require 'test_helper'
 
 module Capistrano::Fiesta
   class StoryTest < Minitest::Test
-    def test_title
+    def test_title_as_release_note
       pr = OpenStruct.new(title: "New [Cool Stuff] feature [Delivers #2123123]")
-      assert_equal "New [Cool Stuff] feature", Story.new(pr).title
+      assert_equal "New [Cool Stuff] feature", Story.new(pr).release_note
     end
 
-    def test_title_with_trello_id
+    def test_title_with_trello_id_as_release_note
       pr = OpenStruct.new(title: "New [Cool Stuff] feature [Delivers #[586f50b384a655b5c009c4ca]")
-      assert_equal "New [Cool Stuff] feature", Story.new(pr).title
+      assert_equal "New [Cool Stuff] feature", Story.new(pr).release_note
+    end
+
+    def test_release_note_in_body
+      pr = OpenStruct.new(body: "_Release note: This thing is amazing_")
+      assert_equal "This thing is amazing", Story.new(pr).release_note
     end
 
     def test_images


### PR DESCRIPTION
Adding something like

```
_Release note: New search feature, please try it out_
```

to a PR's body, will use that instead of the title when composing release notes.
Could maybe skip the composing step if this turns out to be useful?