### PR TITLE
Handle the case where ENV["EDITOR"] contains space

### DIFF
--- a/lib/capistrano/fiesta/editor.rb
+++ b/lib/capistrano/fiesta/editor.rb
@@ -21,7 +21,7 @@ module Capistrano
         end
 
         def open
-          system(ENV["EDITOR"] || "vi", file.path)
+          system(*(ENV["EDITOR"] || "vi").split, file.path)
         end
 
         def read


### PR DESCRIPTION
`system` command actually requires all arguments of a command to be
passed as arguments to the method. This commit fixes an issue where user
may have `ENV["EDITOR"]` that contains arguments in it (such as
`mvim -f`).