### PR TITLE
Find pull requests merged between revisions

### DIFF
--- a/lib/capistrano/fiesta/report.rb
+++ b/lib/capistrano/fiesta/report.rb
@@ -14,7 +14,7 @@ module Capistrano
   module Fiesta
     class Report
       extend AttrExtras.mixin
-      pattr_initialize :github_url, [:last_release, :comment, :auto_compose]
+      pattr_initialize :github_url, [:current_revision, :previous_revision, :comment, :auto_compose]
       attr_query :auto_compose?
 
       def announce(config = {})
@@ -70,20 +70,33 @@ module Capistrano
         end
 
         def merged_pull_requests
-          github.search_issues("base:master repo:#{repo} merged:>#{last_released_at}").items
-        rescue Octokit::UnprocessableEntity => e
-          Logger.warn "Unable to access GitHub. Message given was: #{e.message}"
+          merged_pull_request_numbers.map do |number|
+            begin
+              github.pull_request(repo, number)
+            rescue Octokit::NotFound
+              nil
+            end
+          end.compact
+        end
+
+        def merged_pull_request_numbers
+          commits.map do |commit|
+            commit.commit.message.slice(/\AMerge pull request #(\d+) /, 1)
+          end.compact
+        end
+
+        def commits
+          if previous_revision && current_revision
+            github.compare(repo, previous_revision, current_revision).commits.reverse
+          else
+            []
+          end
+        rescue Octokit::NotFound
           []
         end
 
         def repo
           github_url.match(/github.com[:\/](\S+\/\S+)\.git/)[1]
-        end
-
-        def last_released_at
-          if last_release
-            Time.parse(last_release + "Z00:00").iso8601
-          end
         end
 
         def github

--- a/lib/capistrano/tasks/fiesta.rake
+++ b/lib/capistrano/tasks/fiesta.rake
@@ -7,16 +7,10 @@ namespace :fiesta do
     end
   end
 
-  desc "Generate a fiesta report"
-  task :generate do
-    run_locally do
-      set :fiesta_report, build_report
-    end
-  end
-
   desc "Announce a fiesta report"
   task :announce do
     run_locally do
+      report = build_report
       report.announce(slack_params)
       report.create_release(timestamp)
       Capistrano::Fiesta::Logger.logs.each { |log| warn log }
@@ -27,25 +21,13 @@ namespace :fiesta do
     Capistrano::Fiesta::Report.new(repo_url, report_options)
   end
 
-  def report
-    fetch(:fiesta_report)
-  end
-
   def report_options
     {
-      last_release: last_release,
+      current_revision: fetch(:current_revision),
+      previous_revision: fetch(:previous_revision),
       comment: fetch(:fiesta_comment),
       auto_compose: fetch(:fiesta_auto_compose)
     }
-  end
-
-  def last_release
-    last_release = nil
-    on roles(:web).first do
-      last_release_path = capture("readlink #{current_path}")
-      last_release = last_release_path.split("/").last
-    end
-    last_release
   end
 
   def master_branch?
@@ -71,5 +53,4 @@ namespace :fiesta do
   end
 end
 
-before "deploy:starting", "fiesta:generate"
 after "deploy:finished", "fiesta:announce"


### PR DESCRIPTION
I would like to have capistrano-fiesta use the current revision and the previous revision to find pull requests merged rather than the previous deployment time because

- The release doesn't necessarily include all the PRs merged after the previous deployment.
- I think the revisions are more likely to be available in a broader range of cases than the previous deployment time.
- The revisions we deploy may not be in the master branch.

The downside of this change is we have to call GitHub [API](https://developer.github.com/v3/pulls/#get-a-single-pull-request) for each PR. We might be able to mitigate this by squashing multiple requests into a [Search Issues API](https://developer.github.com/v3/search/#search-issues) request by passing multiple SHA hashes of commits as the `q` parameter, but we still need to call the API multiple times if we have PRs that doesn't fit into a single search request.