### PR TITLE
Extract repo from repo_url in fiesta.rake

### DIFF
--- a/lib/capistrano/fiesta.rb
+++ b/lib/capistrano/fiesta.rb
@@ -1,3 +1,4 @@
+require "capistrano/fiesta/repo_url_parser"
 require "capistrano/fiesta/report"
 
 load File.expand_path("../tasks/fiesta.rake", __FILE__)

--- a/lib/capistrano/fiesta/repo_url_parser.rb
+++ b/lib/capistrano/fiesta/repo_url_parser.rb
@@ -1,0 +1,14 @@
+require "attr_extras/explicit"
+
+module Capistrano
+  module Fiesta
+    class RepoUrlParser
+      extend AttrExtras.mixin
+      pattr_initialize :repo_url
+
+      def repo
+        repo_url.slice(/github.com[:\/](\S+\/\S+)\.git/, 1)
+      end
+    end
+  end
+end

--- a/lib/capistrano/fiesta/report.rb
+++ b/lib/capistrano/fiesta/report.rb
@@ -14,7 +14,7 @@ module Capistrano
   module Fiesta
     class Report
       extend AttrExtras.mixin
-      pattr_initialize :github_url, [:last_release, :comment, :auto_compose]
+      pattr_initialize :repo, [:last_release, :comment, :auto_compose]
       attr_query :auto_compose?
 
       def announce(config = {})
@@ -74,10 +74,6 @@ module Capistrano
         rescue Octokit::UnprocessableEntity => e
           Logger.warn "Unable to access GitHub. Message given was: #{e.message}"
           []
-        end
-
-        def repo
-          github_url.match(/github.com[:\/](\S+\/\S+)\.git/)[1]
         end
 
         def last_released_at

--- a/lib/capistrano/tasks/fiesta.rake
+++ b/lib/capistrano/tasks/fiesta.rake
@@ -28,7 +28,7 @@ namespace :fiesta do
   end
 
   def repo
-    repo_url.slice(/github.com[:\/](\S+\/\S+)\.git/, 1)
+    RepoUrlParser.new(repo_url).repo
   end
 
   def report

--- a/lib/capistrano/tasks/fiesta.rake
+++ b/lib/capistrano/tasks/fiesta.rake
@@ -24,7 +24,11 @@ namespace :fiesta do
   end
 
   def build_report
-    Capistrano::Fiesta::Report.new(repo_url, report_options)
+    Capistrano::Fiesta::Report.new(repo, report_options)
+  end
+
+  def repo
+    repo_url.slice(/github.com[:\/](\S+\/\S+)\.git/, 1)
   end
 
   def report

--- a/test/repo_url_parser_test.rb
+++ b/test/repo_url_parser_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+module Capistrano::Fiesta
+  class RepoUrlParserTest < Minitest::Test
+    def test_ssh_url
+      parser = RepoUrlParser.new("git@github.com:balvig/capistrano-fiesta.git")
+      assert_equal "balvig/capistrano-fiesta", parser.repo
+    end
+
+    def test_clone_url
+      parser = RepoUrlParser.new("https://github.com/balvig/capistrano-fiesta.git")
+      assert_equal "balvig/capistrano-fiesta", parser.repo
+    end
+  end
+end

--- a/test/report_test.rb
+++ b/test/report_test.rb
@@ -94,7 +94,7 @@ module Capistrano::Fiesta
     private
 
       def repo
-        "git@github.com:balvig/capistrano-fiesta.git"
+        "balvig/capistrano-fiesta"
       end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+require 'capistrano/fiesta/repo_url_parser'
 require 'capistrano/fiesta/report'
 require 'minitest/autorun'
 require 'minitest/reporters'


### PR DESCRIPTION
To expel capistrano dependent code from `Capistrano::Fiesta::Report` as part of making capistrano integration optional.