### PR TITLE
Parse release timestamp in fiesta.rake

### DIFF
--- a/lib/capistrano/fiesta/report.rb
+++ b/lib/capistrano/fiesta/report.rb
@@ -9,6 +9,7 @@ require "capistrano/fiesta/logger"
 require "capistrano/fiesta/story"
 require "capistrano/fiesta/auto_composed_story"
 require "capistrano/fiesta/release"
+require "capistrano/fiesta/timestamp_normalizer"
 
 module Capistrano
   module Fiesta
@@ -74,6 +75,12 @@ module Capistrano
         rescue Octokit::UnprocessableEntity => e
           Logger.warn "Unable to access GitHub. Message given was: #{e.message}"
           []
+        end
+
+        def last_released_at
+          if @last_released_at
+            TimestampNormalizer.new(@last_released_at).run
+          end
         end
 
         def github

--- a/lib/capistrano/fiesta/report.rb
+++ b/lib/capistrano/fiesta/report.rb
@@ -14,7 +14,7 @@ module Capistrano
   module Fiesta
     class Report
       extend AttrExtras.mixin
-      pattr_initialize :repo, [:last_release, :comment, :auto_compose]
+      pattr_initialize :repo, [:last_released_at, :comment, :auto_compose]
       attr_query :auto_compose?
 
       def announce(config = {})
@@ -70,16 +70,10 @@ module Capistrano
         end
 
         def merged_pull_requests
-          github.search_issues("base:master repo:#{repo} merged:>#{last_released_at}").items
+          github.search_issues("base:master repo:#{repo} merged:>#{last_released_at&.iso8601}").items
         rescue Octokit::UnprocessableEntity => e
           Logger.warn "Unable to access GitHub. Message given was: #{e.message}"
           []
-        end
-
-        def last_released_at
-          if last_release
-            Time.parse(last_release + "Z00:00").iso8601
-          end
         end
 
         def github

--- a/lib/capistrano/fiesta/report.rb
+++ b/lib/capistrano/fiesta/report.rb
@@ -71,7 +71,7 @@ module Capistrano
         end
 
         def merged_pull_requests
-          github.search_issues("base:master repo:#{repo} merged:>#{last_released_at&.iso8601}").items
+          github.search_issues("base:master repo:#{repo} merged:>#{last_released_at}").items
         rescue Octokit::UnprocessableEntity => e
           Logger.warn "Unable to access GitHub. Message given was: #{e.message}"
           []
@@ -79,7 +79,7 @@ module Capistrano
 
         def last_released_at
           if @last_released_at
-            TimestampNormalizer.new(@last_released_at).run
+            TimestampNormalizer.new(@last_released_at).run.iso8601
           end
         end
 

--- a/lib/capistrano/fiesta/timestamp_normalizer.rb
+++ b/lib/capistrano/fiesta/timestamp_normalizer.rb
@@ -1,0 +1,18 @@
+require "attr_extras/explicit"
+
+module Capistrano
+  module Fiesta
+    class TimestampNormalizer
+      extend AttrExtras.mixin
+      pattr_initialize :timestamp
+
+      def run
+        if timestamp.is_a?(Time)
+          timestamp
+        else
+          Time.parse(timestamp.to_s + "Z")
+        end
+      end
+    end
+  end
+end

--- a/lib/capistrano/tasks/fiesta.rake
+++ b/lib/capistrano/tasks/fiesta.rake
@@ -37,16 +37,10 @@ namespace :fiesta do
 
   def report_options
     {
-      last_released_at: last_released_at,
+      last_released_at: last_release,
       comment: fetch(:fiesta_comment),
       auto_compose: fetch(:fiesta_auto_compose)
     }
-  end
-
-  def last_released_at
-    if last_release
-      Time.parse(last_release + "Z")
-    end
   end
 
   def last_release

--- a/lib/capistrano/tasks/fiesta.rake
+++ b/lib/capistrano/tasks/fiesta.rake
@@ -37,10 +37,16 @@ namespace :fiesta do
 
   def report_options
     {
-      last_release: last_release,
+      last_released_at: last_released_at,
       comment: fetch(:fiesta_comment),
       auto_compose: fetch(:fiesta_auto_compose)
     }
+  end
+
+  def last_released_at
+    if last_release
+      Time.parse(last_release + "Z")
+    end
   end
 
   def last_release

--- a/test/report_test.rb
+++ b/test/report_test.rb
@@ -20,7 +20,7 @@ module Capistrano::Fiesta
       expected = <<-ANNOUNCEMENT
 • New login
       ANNOUNCEMENT
-      announcement = Report.new(repo, last_release: "20151009145023").announce
+      announcement = Report.new(repo, last_released_at: Time.parse("2015-10-09T14:50:23Z")).announce
       assert_equal expected, announcement
       assert_requested github
     end
@@ -87,7 +87,7 @@ module Capistrano::Fiesta
       expected = <<-ANNOUNCEMENT
 • New feature
       ANNOUNCEMENT
-      announcement = Report.new(repo, last_release: "20151009145023", auto_compose: true).announce
+      announcement = Report.new(repo, last_released_at: Time.parse("2015-10-09T14:50:23Z"), auto_compose: true).announce
       assert_equal expected, announcement
     end
 

--- a/test/report_test.rb
+++ b/test/report_test.rb
@@ -20,7 +20,7 @@ module Capistrano::Fiesta
       expected = <<-ANNOUNCEMENT
 • New login
       ANNOUNCEMENT
-      announcement = Report.new(repo, last_released_at: Time.parse("2015-10-09T14:50:23Z")).announce
+      announcement = Report.new(repo, last_released_at: "20151009145023").announce
       assert_equal expected, announcement
       assert_requested github
     end
@@ -87,7 +87,7 @@ module Capistrano::Fiesta
       expected = <<-ANNOUNCEMENT
 • New feature
       ANNOUNCEMENT
-      announcement = Report.new(repo, last_released_at: Time.parse("2015-10-09T14:50:23Z"), auto_compose: true).announce
+      announcement = Report.new(repo, last_released_at: "20151009145023", auto_compose: true).announce
       assert_equal expected, announcement
     end
 

--- a/test/timestamp_normalizer_test.rb
+++ b/test/timestamp_normalizer_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+module Capistrano::Fiesta
+  class TimestampNormalizerTest < Minitest::Test
+    def test_normalizing_timestamps
+      time = Time.parse("2015-10-09T14:50:23Z")
+
+      assert_equal time, TimestampNormalizer.new("20151009145023").run
+      assert_equal time, TimestampNormalizer.new(time).run
+    end
+  end
+end


### PR DESCRIPTION
To expel Capistrano dependent code from `Capistrano::Fiesta::Report` as part of making Capistrano integration optional #15.

I'm wondering if it's worth extracting `Time.parse(last_release + "Z")` to a new class to write a test like we did with `RepoUrlParser`.