### PR TITLE
Update Rubies on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 notifications:
   email: false
 rvm:
-  - 2.2.2
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 sudo: false


### PR DESCRIPTION
Ruby 2.2 has reached EOL as of May 31st 2018.

I believe the CI check in #20 would be green with this change.