### PR TITLE
Disable creating GitHub releases

### DIFF
--- a/lib/capistrano/fiesta/version.rb
+++ b/lib/capistrano/fiesta/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Fiesta
-    VERSION = "1.5.2"
+    VERSION = "2.0.0"
   end
 end

--- a/lib/capistrano/tasks/fiesta.rake
+++ b/lib/capistrano/tasks/fiesta.rake
@@ -18,7 +18,6 @@ namespace :fiesta do
   task :announce do
     run_locally do
       report.announce(slack_params)
-      report.create_release(timestamp)
       Capistrano::Fiesta::Logger.logs.each { |log| warn log }
     end
   end


### PR DESCRIPTION
Since we've started auto-deploying from master, these releases are noisy than useful 😅 

Leaving in the capability for now, can maybe consider an option for it if we find we need it!