### PR TITLE
Makes release note marker case insensitive and supports plural

### DIFF
--- a/lib/capistrano/fiesta/story.rb
+++ b/lib/capistrano/fiesta/story.rb
@@ -29,7 +29,7 @@ module Capistrano
         end
 
         def release_note_in_body
-          @_release_note_in_body ||= pr.body.to_s[/_Release\snote\:?\s(.+?)_/m, 1]
+          @_release_note_in_body ||= pr.body.to_s[/_Release\snotes?\:?\s(.+?)_/im, 1]
         end
     end
   end

--- a/test/story_test.rb
+++ b/test/story_test.rb
@@ -22,6 +22,16 @@ module Capistrano::Fiesta
       assert_equal "This thing is amazing", Story.new(pr).release_note
     end
 
+    def test_release_note_in_body_with_different_capitalization
+      pr = OpenStruct.new(body: "_Release Note: This thing is amazing_")
+      assert_equal "This thing is amazing", Story.new(pr).release_note
+    end
+
+    def test_release_note_in_body_with_plurals
+      pr = OpenStruct.new(body: "_Release Notes: This thing is amazing_")
+      assert_equal "This thing is amazing", Story.new(pr).release_note
+    end
+
     def test_images
       pr = OpenStruct.new(body: "one pic http://github.com/avatar.jpg and another http://google.com/fish.png")
       assert_equal %w{http://github.com/avatar.jpg http://google.com/fish.png}, Story.new(pr).images


### PR DESCRIPTION
Often we forgot which capitalization is used ("Release note", "release note", or "Release Note") or whether it is plural or singular.