### PR TITLE
Fix ENV configuration being ignored

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 notifications:
   email: false
 rvm:
-  - 2.3.7
   - 2.4.4
   - 2.5.1
 sudo: false

--- a/lib/capistrano/fiesta/github.rb
+++ b/lib/capistrano/fiesta/github.rb
@@ -23,7 +23,7 @@ module Capistrano
         end
 
         def default_config
-          { access_token: hub_config["oauth_token"] }
+          { access_token: hub_config["oauth_token"] }.compact
         end
 
         def hub_config_path

--- a/lib/capistrano/fiesta/version.rb
+++ b/lib/capistrano/fiesta/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Fiesta
-    VERSION = "2.1.0"
+    VERSION = "2.1.1"
   end
 end

--- a/test/github_test.rb
+++ b/test/github_test.rb
@@ -7,5 +7,9 @@ module Capistrano::Fiesta
 
       assert_equal "ACCESS TOKEN", Github.client.access_token
     end
+
+    def test_access_token_defaulting_to_env_value
+      refute Github.client.access_token.nil?, "Expected `access_token` to get set from OCTOKIT_ACCESS_TOKEN"
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,11 @@
+# Set dummy ENV
+ENV["OCTOKIT_ACCESS_TOKEN"] = "token-value"
+
+# Require files to test
 require 'capistrano/fiesta/repo_url_parser'
 require 'capistrano/fiesta/report'
+
+# Additional tooling
 require 'minitest/autorun'
 require 'minitest/reporters'
 require 'pry'


### PR DESCRIPTION
A [recent change in Octokit](https://github.com/octokit/octokit.rb/pull/1091) means that passing in `{ access_token: nil }` now actually sets the token to be `nil` and ignores the `ENV` value.