### PR TITLE
Allow testing with bundler 2

### DIFF
--- a/capistrano-fiesta.gemspec
+++ b/capistrano-fiesta.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "capistrano", "~> 3.1"
   spec.add_dependency "octokit", "~> 4.1"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", ">= 1.10", "< 3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "minitest-line"


### PR DESCRIPTION
Currently CI is failing due to:

```
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.10)
```
https://travis-ci.org/balvig/capistrano-fiesta/jobs/549562911