### PR TITLE
Reset Github.config after test

### DIFF
--- a/test/github_test.rb
+++ b/test/github_test.rb
@@ -6,6 +6,8 @@ module Capistrano::Fiesta
       Github.config = { access_token: "ACCESS TOKEN" }
 
       assert_equal "ACCESS TOKEN", Github.client.access_token
+
+      Github.config = nil
     end
 
     def test_access_token_defaulting_to_env_value


### PR DESCRIPTION
otherwise CI fails when `test_access_token_defaulting_to_env_value` is run after `test_client_being_configurable`.

```
Capistrano::Fiesta::GithubTest
  test_client_being_configurable                                  PASS (0.00s)
  test_access_token_defaulting_to_env_value                       FAIL (0.00s)
        Expected `access_token` to get set from OCTOKIT_ACCESS_TOKEN.
        Expected: "token-value"
          Actual: "ACCESS TOKEN"
        /home/travis/build/balvig/capistrano-fiesta/test/github_test.rb:13:in `test_access_token_defaulting_to_env_value'
```

https://travis-ci.org/balvig/capistrano-fiesta/jobs/549580575