### PR TITLE
Fix problem with repository with non-master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Fiesta helps integrate deployment tools with GitHub pull requests and Slack, mak
 sharing release reports with the rest of the team a breeze.
 
 When deploying, Fiesta will compile an editable list of pull
-requests merged to master since the last release, pulling out any images from the descriptions so they can be attached as screenshots:
+requests merged to the default branch since the last release,
+pulling out any images from the descriptions so they can be attached as screenshots:
 
 <img src="https://cloud.githubusercontent.com/assets/104138/10676263/57b6bb44-7905-11e5-8df3-38e96a2a0685.png" width="60%" />
 

--- a/lib/fiesta/report.rb
+++ b/lib/fiesta/report.rb
@@ -70,7 +70,8 @@ module Fiesta
       end
 
       def merged_pull_requests
-        github.search_issues("base:master repo:#{repo} merged:>#{last_released_at}").items
+        default_branch = github.repo(repo).default_branch
+        github.search_issues("base:#{default_branch} repo:#{repo} merged:>#{last_released_at}").items
       rescue Octokit::UnprocessableEntity => e
         Logger.warn "Unable to access GitHub. Message given was: #{e.message}"
         []

--- a/lib/fiesta/report.rb
+++ b/lib/fiesta/report.rb
@@ -70,11 +70,14 @@ module Fiesta
       end
 
       def merged_pull_requests
-        default_branch = github.repo(repo).default_branch
         github.search_issues("base:#{default_branch} repo:#{repo} merged:>#{last_released_at}").items
       rescue Octokit::UnprocessableEntity => e
         Logger.warn "Unable to access GitHub. Message given was: #{e.message}"
         []
+      end
+
+      def default_branch
+        github.repo(repo).default_branch
       end
 
       def last_released_at

--- a/test/report_test.rb
+++ b/test/report_test.rb
@@ -14,6 +14,7 @@ module Fiesta
     end
 
     def test_announce
+      stub_github_repository_request
       query = "base:master repo:balvig/fiesta merged:>2015-10-09T14:50:23Z"
       response = { items: [{ title: "New login [Delivers #123]", body: "" }] }
       github = stub_request(:get, "https://api.github.com:443/search/issues").with(query: { q: query }).to_return_json(response)
@@ -27,6 +28,7 @@ module Fiesta
     end
 
     def test_announce_with_comment
+      stub_github_repository_request
       expected = <<-ANNOUNCEMENT
 • New login
       ANNOUNCEMENT
@@ -37,6 +39,7 @@ module Fiesta
     end
 
     def test_creating_release_on_github
+      stub_github_repository_request
       release_endpoint = stub_request(:post, "https://api.github.com/repos/balvig/fiesta/releases").with(body: { name: "20151009145023", body: "- [New login](www.github.com)", tag_name: "release-20151009145023" })
       Report.new(repo).create_release('20151009145023')
       assert_requested release_endpoint
@@ -51,6 +54,7 @@ module Fiesta
     end
 
     def test_announce_with_options
+      stub_github_repository_request
       stub = stub_request(:post, webhook).with(body: { text: "• New login\n" })
       Report.new(repo).announce(webhook: webhook)
       assert_requested stub
@@ -63,6 +67,7 @@ module Fiesta
     end
 
     def test_announce_with_auto_compose_mode
+      stub_github_repository_request
       response = {
         items: [
           { title: "No release note in body", body: "No notes" },
@@ -80,6 +85,10 @@ module Fiesta
     end
 
     private
+
+      def stub_github_repository_request
+        stub_request(:get, "https://api.github.com/repos/balvig/fiesta").to_return_json(default_branch: "master")
+      end
 
       def repo
         "balvig/fiesta"


### PR DESCRIPTION
This commit makes `Fiesta::Report` request default branch name from GitHub and uses that as a search parameter instead of the hard-coded `master` value.

Note that there's another place (Capistrano script) that still hard-coded the value `master` but I decided to leave that out as I don't think we use that anymore.